### PR TITLE
Windows highdpi2

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1121,6 +1121,26 @@ extern "C" {
  */
 #define SDL_HINT_RENDER_DIRECT3D11_DEBUG    "SDL_RENDER_DIRECT3D11_DEBUG"
 
+ /**
+ *  \brief If set to 1, then allow high-DPI on all windows.
+ *
+ * If high-DPI is allowed, the framebuffer size (which can be queried by calling SDL_GL_GetDrawableSize,
+ * and returns a size in pixels) is decoupled from the SDL window size. SDL window sizes are in
+ * points, which are translated to pixels by multiplying by the scale factor of the monitor that
+ * the window is on.
+ *
+ * If high-DPI is not enabled with this hint, the framebuffer size will be equal to the window size
+ * returned by SDL_GetWindowSize, but the OS will scale up the framebuffer if the window is on a
+ * high-DPI monitor.
+ *
+ * An SDL_WINDOWEVENT_RESIZED event will be sent to the application when the framebuffer size changes,
+ * which could happen in response to the window moving to a monitor with a different scale factor
+ * (either from the user moving it, or SDL_SetWindowPosition), or the monitor's scale factor changing.
+ *
+ * High-DPI support is currently implemented on macOS and Windows.
+ */
+#define SDL_HINT_VIDEO_ALLOW_HIGHDPI "SDL_VIDEO_ALLOW_HIGHDPI"
+
 /**
  *  \brief  A variable controlling whether the Direct3D device is initialized for thread-safe operations.
  *

--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1141,13 +1141,6 @@ extern "C" {
  */
 #define SDL_HINT_VIDEO_ALLOW_HIGHDPI "SDL_VIDEO_ALLOW_HIGHDPI"
 
- /**
- *  \brief Declare DPI awareness, without enabling SDL's DPI-scaled points coordinate system
- * 
- * See SDL_HINT_VIDEO_ALLOW_HIGHDPI
- */
-#define SDL_HINT_WINDOWS_DECLARE_DPI_AWARE "SDL_HINT_WINDOWS_DECLARE_DPI_AWARE"
-
 /**
  *  \brief  A variable controlling whether the Direct3D device is initialized for thread-safe operations.
  *

--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1141,6 +1141,13 @@ extern "C" {
  */
 #define SDL_HINT_VIDEO_ALLOW_HIGHDPI "SDL_VIDEO_ALLOW_HIGHDPI"
 
+ /**
+ *  \brief Declare DPI awareness, without enabling SDL's DPI-scaled points coordinate system
+ * 
+ * See SDL_HINT_VIDEO_ALLOW_HIGHDPI
+ */
+#define SDL_HINT_WINDOWS_DECLARE_DPI_AWARE "SDL_HINT_WINDOWS_DECLARE_DPI_AWARE"
+
 /**
  *  \brief  A variable controlling whether the Direct3D device is initialized for thread-safe operations.
  *

--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -116,7 +116,8 @@ typedef enum
     SDL_WINDOW_FOREIGN = 0x00000800,            /**< window not created by SDL */
     SDL_WINDOW_ALLOW_HIGHDPI = 0x00002000,      /**< window should be created in high-DPI mode if supported.
                                                      On macOS NSHighResolutionCapable must be set true in the
-                                                     application's Info.plist for this to have any effect. */
+                                                     application's Info.plist for this to have any effect. 
+                                                     (deprecated, use SDL_HINT_VIDEO_ALLOW_HIGHDPI) */
     SDL_WINDOW_MOUSE_CAPTURE    = 0x00004000,   /**< window has mouse captured (unrelated to MOUSE_GRABBED) */
     SDL_WINDOW_ALWAYS_ON_TOP    = 0x00008000,   /**< window should always be above others */
     SDL_WINDOW_SKIP_TASKBAR     = 0x00010000,   /**< window should not be added to the taskbar */

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -343,6 +343,7 @@ D3D_WindowEvent(SDL_Renderer * renderer, const SDL_WindowEvent *event)
 
     if (event->event == SDL_WINDOWEVENT_SIZE_CHANGED) {
         data->updateSize = SDL_TRUE;
+        D3D_ActivateRenderer(renderer);
     }
 }
 

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -300,8 +300,7 @@ D3D_ActivateRenderer(SDL_Renderer * renderer)
         SDL_Window *window = renderer->window;
         int w, h;
         Uint32 window_flags = SDL_GetWindowFlags(window);
-
-        SDL_GetWindowSize(window, &w, &h);
+        WIN_GetDrawableSize(window, &w, &h);
         data->pparams.BackBufferWidth = w;
         data->pparams.BackBufferHeight = h;
         if (window_flags & SDL_WINDOW_FULLSCREEN && (window_flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
@@ -345,6 +344,13 @@ D3D_WindowEvent(SDL_Renderer * renderer, const SDL_WindowEvent *event)
     if (event->event == SDL_WINDOWEVENT_SIZE_CHANGED) {
         data->updateSize = SDL_TRUE;
     }
+}
+
+static int
+D3D_GetOutputSize(SDL_Renderer * renderer, int *w, int *h)
+{
+    WIN_GetDrawableSize(renderer->window, w, h);
+    return 0;
 }
 
 static D3DBLEND GetBlendFunc(SDL_BlendFactor factor)
@@ -1571,6 +1577,7 @@ D3D_CreateRenderer(SDL_Window * window, Uint32 flags)
     }
 
     renderer->WindowEvent = D3D_WindowEvent;
+    renderer->GetOutputSize = D3D_GetOutputSize;
     renderer->SupportsBlendMode = D3D_SupportsBlendMode;
     renderer->CreateTexture = D3D_CreateTexture;
     renderer->UpdateTexture = D3D_UpdateTexture;
@@ -1600,7 +1607,7 @@ D3D_CreateRenderer(SDL_Window * window, Uint32 flags)
     SDL_GetWindowWMInfo(window, &windowinfo);
 
     window_flags = SDL_GetWindowFlags(window);
-    SDL_GetWindowSize(window, &w, &h);
+    WIN_GetDrawableSize(window, &w, &h);
     SDL_GetWindowDisplayMode(window, &fullscreen_mode);
 
     SDL_zero(pparams);

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -910,7 +910,7 @@ D3D11_CreateWindowSizeDependentResources(SDL_Renderer * renderer)
     /* The width and height of the swap chain must be based on the display's
      * non-rotated size.
      */
-    SDL_GetWindowSize(renderer->window, &w, &h);
+    WIN_GetDrawableSize(renderer->window, &w, &h);
     data->rotation = D3D11_GetCurrentRotation();
     /* SDL_Log("%s: windowSize={%d,%d}, orientation=%d\n", __FUNCTION__, w, h, (int)data->rotation); */
     if (D3D11_IsDisplayRotated90Degrees(data->rotation)) {
@@ -1039,6 +1039,13 @@ D3D11_WindowEvent(SDL_Renderer * renderer, const SDL_WindowEvent *event)
     if (event->event == SDL_WINDOWEVENT_SIZE_CHANGED) {
         D3D11_UpdateForWindowSizeChange(renderer);
     }
+}
+
+static int
+D3D11_GetOutputSize(SDL_Renderer * renderer, int *w, int *h)
+{
+    WIN_GetDrawableSize(renderer->window, w, h);
+    return 0;
 }
 
 static SDL_bool
@@ -2353,6 +2360,7 @@ D3D11_CreateRenderer(SDL_Window * window, Uint32 flags)
     data->identity = MatrixIdentity();
 
     renderer->WindowEvent = D3D11_WindowEvent;
+    renderer->GetOutputSize = D3D11_GetOutputSize;
     renderer->SupportsBlendMode = D3D11_SupportsBlendMode;
     renderer->CreateTexture = D3D11_CreateTexture;
     renderer->UpdateTexture = D3D11_UpdateTexture;

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -27,6 +27,7 @@
 
 #define COBJMACROS
 #include "../../core/windows/SDL_windows.h"
+#include "../../video/windows/SDL_windowswindow.h"
 #include "SDL_hints.h"
 #include "SDL_loadso.h"
 #include "SDL_syswm.h"

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -244,7 +244,7 @@ SDLTest_CommonArg(SDLTest_CommonState * state, int index)
         return 1;
     }
     if (SDL_strcasecmp(argv[index], "--allow-highdpi") == 0) {
-        state->window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+        SDL_SetHint(SDL_HINT_VIDEO_ALLOW_HIGHDPI, "1");
         return 1;
     }
     if (SDL_strcasecmp(argv[index], "--windows") == 0) {

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2348,13 +2348,6 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int *
         textY += lineHeight;
     }
 
-    if (0 == SDL_GetDisplayUsableBounds(windowDisplayIndex, &rect)) {
-        SDL_snprintf(text, sizeof(text), "SDL_GetDisplayUsableBounds: %d,%d, %dx%d",
-                     rect.x, rect.y, rect.w, rect.h);
-        SDLTest_DrawString(renderer, 0, textY, text);
-        textY += lineHeight;
-    }
-
     if (0 == SDL_GetCurrentDisplayMode(windowDisplayIndex, &mode)) {
         SDL_snprintf(text, sizeof(text), "SDL_GetCurrentDisplayMode: %dx%d@%d",
                      mode.w, mode.h, mode.refresh_rate);

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2348,6 +2348,13 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int *
         textY += lineHeight;
     }
 
+    if (0 == SDL_GetDisplayUsableBounds(windowDisplayIndex, &rect)) {
+        SDL_snprintf(text, sizeof(text), "SDL_GetDisplayUsableBounds: %d,%d, %dx%d",
+                     rect.x, rect.y, rect.w, rect.h);
+        SDLTest_DrawString(renderer, 0, textY, text);
+        textY += lineHeight;
+    }
+
     if (0 == SDL_GetCurrentDisplayMode(windowDisplayIndex, &mode)) {
         SDL_snprintf(text, sizeof(text), "SDL_GetCurrentDisplayMode: %dx%d@%d",
                      mode.w, mode.h, mode.refresh_rate);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1517,6 +1517,11 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
         }
     }
 
+    /* This hint adds SDL_WINDOW_ALLOW_HIGHDPI to all windows. */
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_ALLOW_HIGHDPI, SDL_FALSE)) {
+        flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+    }
+
     if (flags & SDL_WINDOW_VULKAN) {
         if (!_this->Vulkan_CreateSurface) {
             SDL_SetError("Vulkan support is either not configured in SDL "

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1179,9 +1179,9 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_RESIZED, w, h);
 
 #ifdef HIGHDPI_DEBUG
-            SDL_Log("WM_WINDOWPOSCHANGED: Windows client rect (pixels): (%d, %d) (%d x %d)\tSDL client rect (points): (%d, %d) (%d x %d)",
+            SDL_Log("WM_WINDOWPOSCHANGED: Windows client rect (pixels): (%d, %d) (%d x %d)\tSDL client rect (points): (%d, %d) (%d x %d) cached dpi %d, windows reported dpi %d",
                 rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top,
-                x, y, w, h);
+                x, y, w, h, data->scaling_dpi, data->videodata->GetDpiForWindow ? data->videodata->GetDpiForWindow(data->hwnd) : 0);
 #endif
 
             /* Forces a WM_PAINT event */

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -657,24 +657,6 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         data = (SDL_WindowData *) GetProp(hwnd, TEXT("SDL_WindowData"));
     }
     if (!data) {
-        /* Request that windows scale the non-client area when moving between monitors.
-           This is only for Windows 10 Anniversary Update.
-           In the Windows 10 Creators Update, this is the default behaviour with a per-monitor V2 context.
-        */
-        switch (msg) {
-            case WM_NCCREATE:
-                {
-                    SDL_VideoDevice *device = SDL_GetVideoDevice();
-                    if (device && device->driverdata) {
-                        SDL_VideoData *data = SDL_static_cast(SDL_VideoData *, device->driverdata);
-                        if (data->highdpi_enabled && data->EnableNonClientDpiScaling) {
-                            data->EnableNonClientDpiScaling(hwnd);
-                        }
-                    }
-                }
-            break;
-        }
-
         return CallWindowProc(DefWindowProc, hwnd, msg, wParam, lParam);
     }
 

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1490,13 +1490,12 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 #ifdef HIGHDPI_DEBUG
             SDL_Log("WM_DPICHANGED: %d to %d\tsuggested rect: (%d, %d), (%dx%d)\n", 
-                data->scaling_xdpi, newDPI,
+                data->scaling_dpi, newDPI,
                 suggestedRect->left, suggestedRect->top, suggestedRect->right - suggestedRect->left, suggestedRect->bottom - suggestedRect->top);
 #endif
 
             /* update the cached DPI value for this window */
-            data->scaling_xdpi = newDPI;
-            data->scaling_ydpi = newDPI;
+            data->scaling_dpi = newDPI;
 
             if (data->videodata->AreDpiAwarenessContextsEqual
                 && data->videodata->GetThreadDpiAwarenessContext

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1451,7 +1451,6 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             const int currentDPI = (int)data->videodata->GetDpiForWindow(hwnd);
             SIZE *sizeInOut = (SIZE *)lParam;
 
-            int x, y, w, h;
             int frame_w, frame_h;
             int query_client_w_win, query_client_h_win;
 
@@ -1509,7 +1508,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         if (data->videodata->highdpi_enabled) {
             const int newDPI = HIWORD(wParam);
             RECT* const suggestedRect = (RECT*)lParam;
-            int x, y, w, h;
+            int w, h;
 
 #ifdef HIGHDPI_DEBUG
             SDL_Log("WM_DPICHANGED: %d to %d\tsuggested rect: (%d, %d), (%dx%d)\n", 

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1167,15 +1167,13 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
             x = rect.left;
             y = rect.top;
-            w = rect.right - rect.left;
-            h = rect.bottom - rect.top;
-            WIN_ScreenRectToSDL(&x, &y, &w, &h);
+            WIN_ScreenPointToSDL(&x, &y);
 
             SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MOVED, x, y);
 
             /* NOTE: important to convert w/h from SDL (points) to Windows (pixels) using 
                WIN_ClientPointToSDL, which uses the window's actual
-               DPI value, rather than WIN_ScreenRectToSDL which guesses. */
+               DPI value. */
             w = rect.right - rect.left;
             h = rect.bottom - rect.top;
             WIN_ClientPointToSDL(data->window, &w, &h);

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1459,11 +1459,18 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             SDL_Log("WM_GETDPISCALEDSIZE: current DPI: %d potential DPI: %d. input size: (%dx%d)", currentDPI, potentialDPI, sizeInOut->cx, sizeInOut->cy);
 #endif
 
-            WIN_AdjustWindowRect(data->window, &x, &y, &w, &h, SDL_TRUE);
+            /* get the frame size in pixels at currentDPI */
+            {
+                DWORD style = GetWindowLong(hwnd, GWL_STYLE);
+                BOOL menu = (style & WS_CHILDWINDOW) ? FALSE : (GetMenu(hwnd) != NULL);
+                RECT rect = {0};
 
-            /* get the frame size */
-            frame_w = w - MulDiv(data->window->w, currentDPI, 96);
-            frame_h = h - MulDiv(data->window->h, currentDPI, 96);
+                if (!(data->window->flags & SDL_WINDOW_BORDERLESS))
+                    data->videodata->AdjustWindowRectExForDpi(&rect, style, menu, 0, currentDPI);
+
+                frame_w = -rect.left + rect.right;
+                frame_h = -rect.top + rect.bottom;
+            }
 
             query_client_w_win = sizeInOut->cx - frame_w;
             query_client_h_win = sizeInOut->cy - frame_h;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -52,7 +52,7 @@
 #include "wmmsg.h"
 #endif
 
-/* #define HIGHDPI_DEBUG */
+#define HIGHDPI_DEBUG
 
 /* Masks for processing the windows KEYDOWN and KEYUP messages */
 #define REPEATED_KEYMASK    (1<<30)

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1513,25 +1513,12 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             /* update the cached DPI value for this window */
             data->scaling_dpi = newDPI;
 
-            if (data->videodata->AreDpiAwarenessContextsEqual
-                && data->videodata->GetThreadDpiAwarenessContext
-                && data->videodata->AreDpiAwarenessContextsEqual(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, data->videodata->GetThreadDpiAwarenessContext()))
-            {
-                /*
-                DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 means that
-                WM_GETDPISCALEDSIZE will have been called, so we can use suggestedRect.
-                */
-                w = suggestedRect->right - suggestedRect->left;
-                h = suggestedRect->bottom - suggestedRect->top;
-            } else {
-                /*
-                The OS does not support WM_GETDPISCALEDSIZE, so we can't use suggestedRect.
-
-                (suggestedRect is calculated by default to preserves the apparent size of the window rect,
-                whereas we want to preserve the apparent size of the client rect.)
-                */
-                WIN_AdjustWindowRect(data->window, &x, &y, &w, &h, SDL_TRUE);
-            }
+            /*
+            DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 means that
+            WM_GETDPISCALEDSIZE will have been called, so we can use suggestedRect.
+            */
+            w = suggestedRect->right - suggestedRect->left;
+            h = suggestedRect->bottom - suggestedRect->top;
             
 #ifdef HIGHDPI_DEBUG
             SDL_Log("WM_DPICHANGED: current SDL window size: (%dx%d)\tcalling SetWindowPos: (%d, %d), (%dx%d)\n",

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -50,6 +50,15 @@ WIN_UpdateDisplayMode(_THIS, LPCWSTR deviceName, DWORD index, SDL_DisplayMode * 
         int logical_width = GetDeviceCaps( hdc, HORZRES );
         int logical_height = GetDeviceCaps( hdc, VERTRES );
 
+        /*
+        If DPI-unaware:
+        - GetDeviceCaps( hdc, HORZRES ) will return the monitor width in points.
+        - DeviceMode.dmPelsWidth is actual pixels (unlike almost all other Windows API's,
+          it's not virtualized when DPI unaware).
+
+        If DPI-aware:
+        - GetDeviceCaps( hdc, HORZRES ) will return pixels, same as DeviceMode.dmPelsWidth
+        */
         mode->w = logical_width;
         mode->h = logical_height;
         
@@ -302,29 +311,6 @@ WIN_InitModes(_THIS)
 }
 
 int
-WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
-{
-    const SDL_DisplayData *data = (const SDL_DisplayData *)display->driverdata;
-    MONITORINFO minfo;
-    BOOL rc;
-
-    SDL_zero(minfo);
-    minfo.cbSize = sizeof(MONITORINFO);
-    rc = GetMonitorInfo(data->MonitorHandle, &minfo);
-
-    if (!rc) {
-        return SDL_SetError("Couldn't find monitor data");
-    }
-
-    rect->x = minfo.rcMonitor.left;
-    rect->y = minfo.rcMonitor.top;
-    rect->w = minfo.rcMonitor.right - minfo.rcMonitor.left;
-    rect->h = minfo.rcMonitor.bottom - minfo.rcMonitor.top;
-
-    return 0;
-}
-
-int
 WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi_out, float * hdpi_out, float * vdpi_out)
 {
     const SDL_DisplayData *displaydata = (SDL_DisplayData *)display->driverdata;
@@ -344,29 +330,21 @@ WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi_out, float * h
         }
     } else {
         // Window 8.0 and below: same DPI for all monitors.
-        HDC hdc;
-        int hdpi_int, vdpi_int, hpoints, vpoints, hpix, vpix;
+        int hpoints, vpoints, hpix, vpix;
         float hinches, vinches;
 
-        hdc = GetDC(NULL);
-        if (hdc == NULL) {
-            return SDL_SetError("GetDC failed");
-        }
-        hdpi_int = GetDeviceCaps(hdc, LOGPIXELSX);
-        vdpi_int = GetDeviceCaps(hdc, LOGPIXELSY);
-        ReleaseDC(NULL, hdc);
-
+        /* NOTE: all of this is just to compute the diagonal DPI. */
         hpoints = GetSystemMetrics(SM_CXVIRTUALSCREEN);
         vpoints = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-        hpix = MulDiv(hpoints, hdpi_int, 96);
-        vpix = MulDiv(vpoints, vdpi_int, 96);
+        hpix = MulDiv(hpoints, videodata->system_xdpi, 96);
+        vpix = MulDiv(vpoints, videodata->system_ydpi, 96);
 
         hinches = (float)hpoints / 96.0f;
         vinches = (float)vpoints / 96.0f;
 
-        hdpi = (float)hdpi_int;
-        vdpi = (float)vdpi_int;
+        hdpi = (float)videodata->system_xdpi;
+        vdpi = (float)videodata->system_ydpi;
         ddpi = SDL_ComputeDiagonalDPI(hpix, vpix, hinches, vinches);
     }
 
@@ -383,12 +361,16 @@ WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi_out, float * h
     return ddpi != 0.0f ? 0 : SDL_SetError("Couldn't get DPI");
 }
 
-int
-WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
+static int
+WIN_GetDisplayBoundsInternal(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect, SDL_bool usable)
 {
     const SDL_DisplayData *data = (const SDL_DisplayData *)display->driverdata;
+    const SDL_VideoData *vid_data = (const SDL_VideoData *)_this->driverdata;
     MONITORINFO minfo;
+    const RECT *rect_win;
     BOOL rc;
+    int x, y;
+    int w, h;
 
     SDL_zero(minfo);
     minfo.cbSize = sizeof(MONITORINFO);
@@ -398,12 +380,155 @@ WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
         return SDL_SetError("Couldn't find monitor data");
     }
 
-    rect->x = minfo.rcWork.left;
-    rect->y = minfo.rcWork.top;
-    rect->w = minfo.rcWork.right - minfo.rcWork.left;
-    rect->h = minfo.rcWork.bottom - minfo.rcWork.top;
+    rect_win = usable ? &minfo.rcWork : &minfo.rcMonitor;
+
+    x = rect_win->left;
+    y = rect_win->top;
+    w = rect_win->right - rect_win->left;
+    h = rect_win->bottom - rect_win->top;
+    WIN_ScreenRectToSDL(&x, &y, &w, &h);
+
+    rect->x = x;
+    rect->y = y;
+    rect->w = w;
+    rect->h = h;
 
     return 0;
+}
+
+int
+WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
+{
+    return WIN_GetDisplayBoundsInternal(_this, display, rect, SDL_FALSE);
+}
+
+int
+WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
+{
+    return WIN_GetDisplayBoundsInternal(_this, display, rect, SDL_TRUE);
+}
+
+static int
+WIN_GetMonitorDPIAndRects(const SDL_VideoData *videodata, HMONITOR monitor, UINT *xdpi, UINT *ydpi, RECT *monitorrect_sdl, RECT *monitorrect_win)
+{
+    HRESULT result;
+    MONITORINFO moninfo = { 0 };
+    UINT unused;
+    int mon_width, mon_height;
+
+    /* Check for Windows < 8.1*/
+    if (!videodata->GetDpiForMonitor) {
+        *xdpi = videodata->system_xdpi;
+        *ydpi = videodata->system_ydpi;
+    } else {
+        result = videodata->GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, xdpi, &unused);
+        *ydpi = *xdpi;
+        if (result != S_OK) {
+            /* Shouldn't happen? */
+            return SDL_SetError("GetDpiForMonitor failed");
+        }
+    }
+
+    moninfo.cbSize = sizeof(MONITORINFO);
+    if (!GetMonitorInfo(monitor, &moninfo)) {
+        /* Shouldn't happen? */
+        return SDL_SetError("GetMonitorInfo failed");
+    }
+
+    *monitorrect_win = moninfo.rcMonitor;
+    *monitorrect_sdl = moninfo.rcMonitor;
+
+    /* fix up the right/bottom of monitorrect_sdl */
+    mon_width = moninfo.rcMonitor.right - moninfo.rcMonitor.left;
+    mon_height = moninfo.rcMonitor.bottom - moninfo.rcMonitor.top;
+    mon_width = MulDiv(mon_width, 96, *xdpi);
+    mon_height = MulDiv(mon_height, 96, *ydpi);
+
+    monitorrect_sdl->right = monitorrect_sdl->left + mon_width;
+    monitorrect_sdl->bottom = monitorrect_sdl->top + mon_height;
+
+    return 0;
+}
+
+/* Convert an SDL to a Windows screen rect. */
+void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h)
+{
+    const SDL_VideoDevice *videodevice = SDL_GetVideoDevice();
+    const SDL_VideoData *videodata;
+    RECT inputrect;
+    RECT monitorrect_sdl, monitorrect_win;
+    UINT xdpi, ydpi;
+    HMONITOR monitor;
+
+    if (!videodevice || !videodevice->driverdata)
+        return;
+
+    videodata = (SDL_VideoData *)videodevice->driverdata;
+    if (!videodata->highdpi_enabled)
+        return;
+
+    /*
+    The trick here is passing SDL coordinates to MonitorFromRect, which expects Windows 
+    coordinates (pixels). This is wrong, but there is no real alternative, and due to
+    the way we derive the SDL coordinate system, it works OK:
+
+    - top-left corner of monitors in SDL coordinates are identical to the top-left corner in Windows coordinates.
+    - the widths/heights of monitors (and windows) in SDL coords are in scaled points,
+      which are equal or less than the corresponding sizes in pixels (because we only support scale factors >=100%)
+    - becuase of the above two points, a rect (in SDL coordinates) that is fully inside 
+      a monitor's bounds (in SDL coordinates) will also be fully inside that monitor's bounds in Windows coordinates.
+    */
+    inputrect.left = *x;
+    inputrect.top = *y;
+    inputrect.right = *x + *w;
+    inputrect.bottom = *y + *h;
+    monitor = MonitorFromRect(&inputrect, MONITOR_DEFAULTTONEAREST);
+
+    if (WIN_GetMonitorDPIAndRects(videodata, monitor, &xdpi, &ydpi, &monitorrect_sdl, &monitorrect_win) == 0) {
+        *w = MulDiv(*w, xdpi, 96);
+        *h = MulDiv(*h, ydpi, 96);
+
+        *x = monitorrect_sdl.left + MulDiv(*x - monitorrect_sdl.left, xdpi, 96);
+        *y = monitorrect_sdl.top + MulDiv(*y - monitorrect_sdl.top, ydpi, 96);
+
+        /* ensure the result is not past the right/bottom of the monitor rect */
+        if (*x >= monitorrect_win.right)
+            *x = monitorrect_win.right - 1;
+        if (*y >= monitorrect_win.bottom)
+            *y = monitorrect_win.bottom - 1;
+    }
+}
+
+/* Converts a Windows screen rect to an SDL one. */
+void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h)
+{
+    const SDL_VideoDevice *videodevice = SDL_GetVideoDevice();
+    const SDL_VideoData *videodata;
+    RECT inputrect;
+    RECT monitorrect_sdl, monitorrect_win;
+    UINT xdpi, ydpi;
+    HMONITOR monitor;
+
+    if (!videodevice || !videodevice->driverdata)
+        return;
+
+    videodata = (SDL_VideoData *)videodevice->driverdata;
+    if (!videodata->highdpi_enabled)
+        return;
+    
+    inputrect.left = *x;
+    inputrect.top = *y;
+    inputrect.right = *x + *w;
+    inputrect.bottom = *y + *h;
+    monitor = MonitorFromRect(&inputrect, MONITOR_DEFAULTTONEAREST);
+
+    if (WIN_GetMonitorDPIAndRects(videodata, monitor, &xdpi, &ydpi, &monitorrect_sdl, &monitorrect_win) == 0) {
+        *w = MulDiv(*w, 96, xdpi);
+        *h = MulDiv(*h, 96, ydpi);
+
+        *x = monitorrect_win.left + MulDiv(*x - monitorrect_win.left, 96, xdpi);
+        *y = monitorrect_win.top + MulDiv(*y - monitorrect_win.top, 96, ydpi);
+    }
 }
 
 void
@@ -432,6 +557,36 @@ WIN_GetDisplayModes(_THIS, SDL_VideoDisplay * display)
     }
 }
 
+#ifdef DEBUG_MODES
+static void
+WIN_LogMonitor(_THIS, HMONITOR mon)
+{
+    const SDL_VideoData *vid_data = (const SDL_VideoData *)_this->driverdata;
+    MONITORINFOEX minfo;
+    UINT xdpi = 0, ydpi = 0;
+    char *name_utf8;
+
+    if (vid_data->GetDpiForMonitor)
+        vid_data->GetDpiForMonitor(mon, MDT_EFFECTIVE_DPI, &xdpi, &ydpi);
+
+    SDL_zero(minfo);
+    minfo.cbSize = sizeof(minfo);
+    GetMonitorInfo(mon, (LPMONITORINFO)&minfo);
+
+    name_utf8 = WIN_StringToUTF8(minfo.szDevice);
+
+    SDL_Log("WIN_LogMonitor: monitor \"%s\": dpi: %d. Windows virtual screen coordinates: (%d, %d), %dx%d",
+        name_utf8,
+        xdpi,
+        minfo.rcMonitor.left,
+        minfo.rcMonitor.top,
+        minfo.rcMonitor.right - minfo.rcMonitor.left,
+        minfo.rcMonitor.bottom - minfo.rcMonitor.top);
+
+    SDL_free(name_utf8);
+}
+#endif
+
 int
 WIN_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
 {
@@ -439,9 +594,35 @@ WIN_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
     SDL_DisplayModeData *data = (SDL_DisplayModeData *) mode->driverdata;
     LONG status;
 
+#ifdef DEBUG_MODES
+    SDL_Log("WIN_SetDisplayMode: monitor before mode change:");
+    WIN_LogMonitor(_this, displaydata->MonitorHandle);
+#endif
+
+    /*
+    High-DPI notes:
+
+    - ChangeDisplaySettingsEx always takes pixels.
+    - e.g. if the display is set to 2880x1800 with 200% scaling in the Control Panel,
+      - calling ChangeDisplaySettingsEx with a dmPelsWidth/Height other than 2880x1800 will
+        change the monitor DPI to 96. (100% scaling)
+      - calling ChangeDisplaySettingsEx with a dmPelsWidth/Height of 2880x1800 (or a NULL DEVMODE*) will
+        reset the monitor DPI to 192. (200% scaling)
+      NOTE: these are temporary changes in DPI, not modifications to the Control Panel setting.
+
+    - Windows bug: windows do not get a WM_DPICHANGED message after a ChangeDisplaySettingsEx, even though the
+      monitor DPI changes
+      (as of Windows 10 Creator's Update, at least)
+    */
     if (mode->driverdata == display->desktop_mode.driverdata) {
+#ifdef DEBUG_MODES
+        SDL_Log("WIN_SetDisplayMode: resetting to original resolution");
+#endif
         status = ChangeDisplaySettingsExW(displaydata->DeviceName, NULL, NULL, CDS_FULLSCREEN, NULL);
     } else {
+#ifdef DEBUG_MODES
+        SDL_Log("WIN_SetDisplayMode: changing to %dx%d pixels", data->DeviceMode.dmPelsWidth, data->DeviceMode.dmPelsHeight);
+#endif
         status = ChangeDisplaySettingsExW(displaydata->DeviceName, &data->DeviceMode, NULL, CDS_FULLSCREEN, NULL);
     }
     if (status != DISP_CHANGE_SUCCESSFUL) {
@@ -462,6 +643,12 @@ WIN_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
         }
         return SDL_SetError("ChangeDisplaySettingsEx() failed: %s", reason);
     }
+
+#ifdef DEBUG_MODES
+    SDL_Log("WIN_SetDisplayMode: monitor after mode change:");
+    WIN_LogMonitor(_this, displaydata->MonitorHandle);
+#endif
+
     EnumDisplaySettingsW(displaydata->DeviceName, ENUM_CURRENT_SETTINGS, &data->DeviceMode);
     WIN_UpdateDisplayMode(_this, displaydata->DeviceName, ENUM_CURRENT_SETTINGS, mode);
     return 0;

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -490,7 +490,11 @@ SDL_GetPointDisplayIndex(int x, int y)
             return i;
         }
 
+        /* Snap x, y to the display rect */
+        closest_x_on_disp = point.x;
+        closest_y_on_disp = point.y;
         SDL_GetClosetPointOnRect(&rect, &closest_x_on_disp, &closest_y_on_disp);
+
         delta.x = point.x - closest_x_on_disp;
         delta.y = point.y - closest_y_on_disp;
         dist = (delta.x*delta.x + delta.y*delta.y);

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -525,13 +525,17 @@ void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h)
     
     inputrect.left = *x;
     inputrect.top = *y;
-    inputrect.right = *x + *w;
-    inputrect.bottom = *y + *h;
+    inputrect.right = *x + (w ? *w : 0);
+    inputrect.bottom = *y + (h ? *h : 0);
     monitor = MonitorFromRect(&inputrect, MONITOR_DEFAULTTONEAREST);
 
     if (WIN_GetMonitorDPIAndRects(videodata, monitor, &xdpi, &ydpi, &monitorrect_sdl, &monitorrect_win) == 0) {
-        *w = MulDiv(*w, 96, xdpi);
-        *h = MulDiv(*h, 96, ydpi);
+        if (w) {
+            *w = MulDiv(*w, 96, xdpi);
+        }
+        if (h) {
+            *h = MulDiv(*h, 96, ydpi);
+        }
 
         *x = monitorrect_win.left + MulDiv(*x - monitorrect_win.left, 96, xdpi);
         *y = monitorrect_win.top + MulDiv(*y - monitorrect_win.top, 96, ydpi);

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -490,7 +490,7 @@ WIN_GetMonitorDPIAndRects(const SDL_VideoData *videodata, HMONITOR monitor, UINT
 }
 
 /* Convert an SDL to a Windows screen rect. */
-void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h)
+void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h, int *dpi)
 {
     const SDL_VideoDevice *videodevice = SDL_GetVideoDevice();
     const SDL_VideoData *videodata;
@@ -535,6 +535,14 @@ void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h)
             *x = monitorrect_win.right - 1;
         if (*y >= monitorrect_win.bottom)
             *y = monitorrect_win.bottom - 1;
+
+        if (dpi) {
+            *dpi = xdpi;
+        }
+    } else {
+        if (dpi) {
+            *dpi = 96;
+        }
     }
 }
 

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -396,12 +396,8 @@ int
 WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
 {
     const SDL_DisplayData *data = (const SDL_DisplayData *)display->driverdata;
-    const SDL_VideoData *vid_data = (const SDL_VideoData *)_this->driverdata;
     MONITORINFO minfo;
-    const RECT *rect_win;
     BOOL rc;
-    int x, y;
-    int w, h;
 
     SDL_zero(minfo);
     minfo.cbSize = sizeof(MONITORINFO);

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -30,7 +30,7 @@
 #define CDS_FULLSCREEN 0
 #endif
 
-/* #define DEBUG_MODES */
+#define DEBUG_MODES
 
 static void
 WIN_UpdateDisplayMode(_THIS, LPCWSTR deviceName, DWORD index, SDL_DisplayMode * mode)

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -538,8 +538,8 @@ void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h)
     }
 }
 
-/* Converts a Windows screen rect to an SDL one. */
-void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h)
+/* Converts a Windows screen point to an SDL one. */
+void WIN_ScreenPointToSDL(int *x, int *y)
 {
     const SDL_VideoDevice *videodevice = SDL_GetVideoDevice();
     const SDL_VideoData *videodata;
@@ -557,18 +557,11 @@ void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h)
     
     inputrect.left = *x;
     inputrect.top = *y;
-    inputrect.right = *x + (w ? *w : 0);
-    inputrect.bottom = *y + (h ? *h : 0);
+    inputrect.right = *x;
+    inputrect.bottom = *y;
     monitor = MonitorFromRect(&inputrect, MONITOR_DEFAULTTONEAREST);
 
     if (WIN_GetMonitorDPIAndRects(videodata, monitor, &xdpi, &ydpi, &monitorrect_sdl, &monitorrect_win) == 0) {
-        if (w) {
-            *w = MulDiv(*w, 96, xdpi);
-        }
-        if (h) {
-            *h = MulDiv(*h, 96, ydpi);
-        }
-
         *x = monitorrect_win.left + MulDiv(*x - monitorrect_win.left, 96, xdpi);
         *y = monitorrect_win.top + MulDiv(*y - monitorrect_win.top, 96, ydpi);
     }

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -498,6 +498,7 @@ void WIN_ScreenPointFromSDL(int *x, int *y, int *dpiOut)
     int displayIndex;
     SDL_Rect bounds;
     float ddpi, hdpi, vdpi;
+    int x_sdl, y_sdl;
 
     if (!videodevice || !videodevice->driverdata)
         return;
@@ -522,8 +523,15 @@ void WIN_ScreenPointFromSDL(int *x, int *y, int *dpiOut)
     /* ddpi/hdpi/vdpi are all identical */
     *dpiOut = ddpi;
 
-    *x = bounds.x + MulDiv(*x - bounds.x, *dpiOut, 96);
-    *y = bounds.y + MulDiv(*y - bounds.y, *dpiOut, 96);
+    x_sdl = *x;
+    y_sdl = *y;
+    *x = bounds.x + MulDiv(x_sdl - bounds.x, (int)ddpi, 96);
+    *y = bounds.y + MulDiv(y_sdl - bounds.y, (int)ddpi, 96);
+
+#ifdef HIGHDPI_DEBUG
+    SDL_Log("WIN_ScreenPointFromSDL: (%d, %d) points -> (%d x %d) pixels, using %d DPI monitor",
+        x_sdl, y_sdl, *x, *y, (int)ddpi);
+#endif
 }
 
 /* Converts a Windows screen point to an SDL one. */
@@ -536,6 +544,7 @@ void WIN_ScreenPointToSDL(int *x, int *y)
     int i, displayIndex;
     SDL_Rect bounds;
     float ddpi, hdpi, vdpi;
+    int x_pixels, y_pixels;
 
     if (!videodevice || !videodevice->driverdata) {
         return;
@@ -568,8 +577,15 @@ void WIN_ScreenPointToSDL(int *x, int *y)
         return;
     }
 
-    *x = bounds.x + MulDiv(*x - bounds.x, 96, (int)ddpi);
-    *y = bounds.y + MulDiv(*y - bounds.y, 96, (int)ddpi);
+    x_pixels = *x;
+    y_pixels = *y;
+    *x = bounds.x + MulDiv(x_pixels - bounds.x, 96, (int)ddpi);
+    *y = bounds.y + MulDiv(y_pixels - bounds.y, 96, (int)ddpi);
+
+#ifdef HIGHDPI_DEBUG
+    SDL_Log("WIN_ScreenPointToSDL: (%d, %d) pixels -> (%d x %d) points, using %d DPI monitor",
+        x_pixels, y_pixels, *x, *y, (int)ddpi);
+#endif
 }
 
 void

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -449,7 +449,7 @@ WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
 }
 
 static void
-SDL_GetClosetPointOnRect(const SDL_Rect *rect, int *x, int *y)
+SDL_GetClosestPointOnRect(const SDL_Rect *rect, int *x, int *y)
 {
     const int right = rect->x + rect->w;
     const int bottom = rect->y + rect->h;
@@ -493,7 +493,7 @@ SDL_GetPointDisplayIndex(int x, int y)
         /* Snap x, y to the display rect */
         closest_x_on_disp = point.x;
         closest_y_on_disp = point.y;
-        SDL_GetClosetPointOnRect(&rect, &closest_x_on_disp, &closest_y_on_disp);
+        SDL_GetClosestPointOnRect(&rect, &closest_x_on_disp, &closest_y_on_disp);
 
         delta.x = point.x - closest_x_on_disp;
         delta.y = point.y - closest_y_on_disp;

--- a/src/video/windows/SDL_windowsmodes.h
+++ b/src/video/windows/SDL_windowsmodes.h
@@ -38,7 +38,7 @@ typedef struct
 extern int WIN_InitModes(_THIS);
 extern int WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 extern int WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
-extern void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h, int *dpi);
+extern void WIN_ScreenPointFromSDL(int *x, int *y, int *dpiOut);
 extern void WIN_ScreenPointToSDL(int *x, int *y);
 extern int WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi);
 extern void WIN_GetDisplayModes(_THIS, SDL_VideoDisplay * display);

--- a/src/video/windows/SDL_windowsmodes.h
+++ b/src/video/windows/SDL_windowsmodes.h
@@ -38,7 +38,7 @@ typedef struct
 extern int WIN_InitModes(_THIS);
 extern int WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 extern int WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
-extern void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h);
+extern void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h, int *dpi);
 extern void WIN_ScreenPointToSDL(int *x, int *y);
 extern int WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi);
 extern void WIN_GetDisplayModes(_THIS, SDL_VideoDisplay * display);

--- a/src/video/windows/SDL_windowsmodes.h
+++ b/src/video/windows/SDL_windowsmodes.h
@@ -38,6 +38,8 @@ typedef struct
 extern int WIN_InitModes(_THIS);
 extern int WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 extern int WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
+extern void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h);
+extern void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h);
 extern int WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi);
 extern void WIN_GetDisplayModes(_THIS, SDL_VideoDisplay * display);
 extern int WIN_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);

--- a/src/video/windows/SDL_windowsmodes.h
+++ b/src/video/windows/SDL_windowsmodes.h
@@ -39,7 +39,7 @@ extern int WIN_InitModes(_THIS);
 extern int WIN_GetDisplayBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 extern int WIN_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
 extern void WIN_ScreenRectFromSDL(int *x, int *y, int *w, int *h);
-extern void WIN_ScreenRectToSDL(int *x, int *y, int *w, int *h);
+extern void WIN_ScreenPointToSDL(int *x, int *y);
 extern int WIN_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi);
 extern void WIN_GetDisplayModes(_THIS, SDL_VideoDisplay * display);
 extern int WIN_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -288,6 +288,7 @@ WIN_WarpMouseGlobal(int x, int y)
 {
     POINT pt;
 
+    WIN_ScreenRectFromSDL(&x, &y, NULL, NULL);
     pt.x = x;
     pt.y = y;
     SetCursorPos(pt.x, pt.y);

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -288,7 +288,7 @@ WIN_WarpMouseGlobal(int x, int y)
 {
     POINT pt;
 
-    WIN_ScreenRectFromSDL(&x, &y, NULL, NULL, NULL);
+    WIN_ScreenPointFromSDL(&x, &y, NULL);
     pt.x = x;
     pt.y = y;
     SetCursorPos(pt.x, pt.y);

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -332,7 +332,7 @@ WIN_GetGlobalMouseState(int *x, int *y)
     GetCursorPos(&pt);
     *x = (int) pt.x;
     *y = (int) pt.y;
-    WIN_ScreenRectToSDL(x, y, NULL, NULL);
+    WIN_ScreenPointToSDL(x, y);
 
     retval |= GetAsyncKeyState(!swapButtons ? VK_LBUTTON : VK_RBUTTON) & 0x8000 ? SDL_BUTTON_LMASK : 0;
     retval |= GetAsyncKeyState(!swapButtons ? VK_RBUTTON : VK_LBUTTON) & 0x8000 ? SDL_BUTTON_RMASK : 0;

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -331,6 +331,7 @@ WIN_GetGlobalMouseState(int *x, int *y)
     GetCursorPos(&pt);
     *x = (int) pt.x;
     *y = (int) pt.y;
+    WIN_ScreenRectToSDL(x, y, NULL, NULL);
 
     retval |= GetAsyncKeyState(!swapButtons ? VK_LBUTTON : VK_RBUTTON) & 0x8000 ? SDL_BUTTON_LMASK : 0;
     retval |= GetAsyncKeyState(!swapButtons ? VK_RBUTTON : VK_LBUTTON) & 0x8000 ? SDL_BUTTON_RMASK : 0;

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -288,7 +288,7 @@ WIN_WarpMouseGlobal(int x, int y)
 {
     POINT pt;
 
-    WIN_ScreenRectFromSDL(&x, &y, NULL, NULL);
+    WIN_ScreenRectFromSDL(&x, &y, NULL, NULL, NULL);
     pt.x = x;
     pt.y = y;
     SetCursorPos(pt.x, pt.y);

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -676,6 +676,8 @@ WIN_GL_CreateContext(_THIS, SDL_Window * window)
         _this->GL_UnloadLibrary = WIN_GLES_UnloadLibrary;
         _this->GL_CreateContext = WIN_GLES_CreateContext;
         _this->GL_MakeCurrent = WIN_GLES_MakeCurrent;
+        // FIXME:
+        //_this->GL_GetDrawableSize = WIN_GLES_GetDrawableSize;
         _this->GL_SetSwapInterval = WIN_GLES_SetSwapInterval;
         _this->GL_GetSwapInterval = WIN_GLES_GetSwapInterval;
         _this->GL_SwapWindow = WIN_GLES_SwapWindow;

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -822,6 +822,12 @@ WIN_GL_MakeCurrent(_THIS, SDL_Window * window, SDL_GLContext context)
     return 0;
 }
 
+void
+WIN_GL_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h)
+{
+    WIN_GetDrawableSize(window, w, h);
+}
+
 int
 WIN_GL_SetSwapInterval(_THIS, int interval)
 {

--- a/src/video/windows/SDL_windowsopengl.h
+++ b/src/video/windows/SDL_windowsopengl.h
@@ -71,6 +71,7 @@ extern int WIN_GL_SetupWindow(_THIS, SDL_Window * window);
 extern SDL_GLContext WIN_GL_CreateContext(_THIS, SDL_Window * window);
 extern int WIN_GL_MakeCurrent(_THIS, SDL_Window * window,
                               SDL_GLContext context);
+extern void WIN_GL_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h);
 extern int WIN_GL_SetSwapInterval(_THIS, int interval);
 extern int WIN_GL_GetSwapInterval(_THIS);
 extern int WIN_GL_SwapWindow(_THIS, SDL_Window * window);

--- a/src/video/windows/SDL_windowsopengles.c
+++ b/src/video/windows/SDL_windowsopengles.c
@@ -40,6 +40,7 @@ WIN_GLES_LoadLibrary(_THIS, const char *path) {
         _this->GL_UnloadLibrary = WIN_GL_UnloadLibrary;
         _this->GL_CreateContext = WIN_GL_CreateContext;
         _this->GL_MakeCurrent = WIN_GL_MakeCurrent;
+        _this->GL_GetDrawableSize = WIN_GL_GetDrawableSize;
         _this->GL_SetSwapInterval = WIN_GL_SetSwapInterval;
         _this->GL_GetSwapInterval = WIN_GL_GetSwapInterval;
         _this->GL_SwapWindow = WIN_GL_SwapWindow;
@@ -72,6 +73,7 @@ WIN_GLES_CreateContext(_THIS, SDL_Window * window)
         _this->GL_UnloadLibrary = WIN_GL_UnloadLibrary;
         _this->GL_CreateContext = WIN_GL_CreateContext;
         _this->GL_MakeCurrent = WIN_GL_MakeCurrent;
+        _this->GL_GetDrawableSize = WIN_GL_GetDrawableSize;
         _this->GL_SetSwapInterval = WIN_GL_SetSwapInterval;
         _this->GL_GetSwapInterval = WIN_GL_GetSwapInterval;
         _this->GL_SwapWindow = WIN_GL_SwapWindow;

--- a/src/video/windows/SDL_windowsopengles.h
+++ b/src/video/windows/SDL_windowsopengles.h
@@ -39,6 +39,7 @@ extern int WIN_GLES_LoadLibrary(_THIS, const char *path);
 extern SDL_GLContext WIN_GLES_CreateContext(_THIS, SDL_Window * window);
 extern int WIN_GLES_SwapWindow(_THIS, SDL_Window * window);
 extern int WIN_GLES_MakeCurrent(_THIS, SDL_Window * window, SDL_GLContext context);
+extern void WIN_GLES_GetDrawableSize(_THIS, SDL_Window* window, int* w, int* h);
 extern void WIN_GLES_DeleteContext(_THIS, SDL_GLContext context);
 extern int WIN_GLES_SetupWindow(_THIS, SDL_Window * window);
 

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -264,6 +264,16 @@ WIN_SetAllowHighDPI(_THIS)
     {
         data->highdpi_enabled = SDL_TRUE;
     }
+
+    // TODO: enabling DPI awareness through Windows Explorer
+    // (right click .exe -> Properties -> Compatibility -> High DPI Settings -> 
+    // check "Override high DPI Scaling behaviour", select Application) gives
+    // a DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE context (at least on Windows 10 21H1)
+    if (data->AreDpiAwarenessContextsEqual
+        && data->GetThreadDpiAwarenessContext
+        && data->AreDpiAwarenessContextsEqual(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE, data->GetThreadDpiAwarenessContext())) {
+        data->highdpi_enabled = SDL_TRUE;
+    }
 }
 
 int

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -286,19 +286,6 @@ WIN_VideoInit(_THIS)
         WIN_SetDPIAware(_this);
     }
 
-    /* Cache LOGPIXELSX/LOGPIXELSY. */
-    {
-        HDC hdc = GetDC(NULL);
-        if (hdc) {
-            data->system_xdpi = GetDeviceCaps(hdc, LOGPIXELSX);
-            data->system_ydpi = GetDeviceCaps(hdc, LOGPIXELSY);
-            ReleaseDC(NULL, hdc);
-        } else {
-            data->system_xdpi = 96;
-            data->system_ydpi = 96;
-        }
-    }
-
     if (WIN_InitModes(_this) < 0) {
         return -1;
     }

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -213,6 +213,8 @@ WIN_CreateDevice(int devindex)
     device->GL_UnloadLibrary = WIN_GLES_UnloadLibrary;
     device->GL_CreateContext = WIN_GLES_CreateContext;
     device->GL_MakeCurrent = WIN_GLES_MakeCurrent;
+    // FIXME:
+    //device->GL_GetDrawableSize = WIN_GLES_GetDrawableSize;
     device->GL_SetSwapInterval = WIN_GLES_SetSwapInterval;
     device->GL_GetSwapInterval = WIN_GLES_GetSwapInterval;
     device->GL_SwapWindow = WIN_GLES_SwapWindow;

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -244,36 +244,15 @@ VideoBootStrap WINDOWS_bootstrap = {
 };
 
 static void
-WIN_SetDPIAware(_THIS)
-{
-    SDL_VideoData *data = SDL_static_cast(SDL_VideoData *, _this->driverdata);
-    if (data->SetProcessDpiAwarenessContext) {
-        /* Windows 10 Anniversary Update+ */
-        /* First, try the Windows 10 Creators Update version */
-        BOOL result = data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        if (!result) {
-            result = data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
-        }
-
-        /*
-        NOTE: The above calls will fail if the DPI awareness was already set outside of SDL.
-        */
-    } else if (data->SetProcessDpiAwareness) {
-        /* Windows 8.1-Windows 10 */
-        HRESULT result = data->SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
-    } else if (data->SetProcessDPIAware) {
-        /* Vista-Windows 8.0 */
-        BOOL success = data->SetProcessDPIAware();
-    }
-}
-
-static void
 WIN_SetAllowHighDPI(_THIS)
 {
     SDL_VideoData *data = SDL_static_cast(SDL_VideoData *, _this->driverdata);
 
     // Declare DPI aware (may have been done in external code or a manifest, as well)
-    WIN_SetDPIAware(_this);
+    if (data->SetProcessDpiAwarenessContext) {
+        /* Windows 10 Creators Update+ */
+        data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
 
     // Check for PMv2 context
     if (data->AreDpiAwarenessContextsEqual
@@ -289,10 +268,6 @@ WIN_VideoInit(_THIS)
 {
     SDL_VideoData *data = (SDL_VideoData *) _this->driverdata;
 
-    /* Set the process DPI awareness */
-    if (SDL_GetHintBoolean(SDL_HINT_WINDOWS_DECLARE_DPI_AWARE, SDL_FALSE)) {
-        WIN_SetDPIAware(_this);
-    }
     /* Check if SDL2 highdpi virtualization was requested */
     if (SDL_GetHintBoolean(SDL_HINT_VIDEO_ALLOW_HIGHDPI, SDL_FALSE)) {
         WIN_SetAllowHighDPI(_this);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -251,9 +251,10 @@ WIN_SetAllowHighDPI(_THIS)
     SDL_VideoData *data = SDL_static_cast(SDL_VideoData *, _this->driverdata);
 
     // Declare DPI aware (may have been done in external code or a manifest, as well)
-    if (data->SetThreadDpiAwarenessContext) {
-        /* Windows 10 Creators Update+ */
-        data->SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    if (data->SetProcessDpiAwarenessContext) {
+        // NOTE: SetThreadDpiAwarenessContext doesn't work here with OpenGL - the OpenGL contents
+        // end up still getting OS scaled. (tested on Windows 10 21H1 19043.1348, NVIDIA 496.49)
+        data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
     }
 
     // Check for PMv2 context

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -225,6 +225,7 @@ WIN_CreateDevice(int devindex)
     device->Vulkan_UnloadLibrary = WIN_Vulkan_UnloadLibrary;
     device->Vulkan_GetInstanceExtensions = WIN_Vulkan_GetInstanceExtensions;
     device->Vulkan_CreateSurface = WIN_Vulkan_CreateSurface;
+    device->Vulkan_GetDrawableSize = WIN_GL_GetDrawableSize;
 #endif
 
     device->StartTextInput = WIN_StartTextInput;

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -295,7 +295,7 @@ WIN_VideoInit(_THIS)
     }
     /* Check if SDL2 highdpi virtualization was requested */
     if (SDL_GetHintBoolean(SDL_HINT_VIDEO_ALLOW_HIGHDPI, SDL_FALSE)) {
-        WIN_SetDPIAware(_this);
+        WIN_SetAllowHighDPI(_this);
     }
 
     if (WIN_InitModes(_this) < 0) {

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -131,6 +131,7 @@ WIN_CreateDevice(int devindex)
         data->AdjustWindowRectExForDpi = (BOOL (WINAPI *)(LPRECT, DWORD, BOOL, DWORD, UINT)) SDL_LoadFunction(data->userDLL, "AdjustWindowRectExForDpi");
         data->GetDpiForWindow = (UINT (WINAPI *)(HWND)) SDL_LoadFunction(data->userDLL, "GetDpiForWindow");
         data->AreDpiAwarenessContextsEqual = (BOOL (WINAPI *)(DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT)) SDL_LoadFunction(data->userDLL, "AreDpiAwarenessContextsEqual");
+        data->IsValidDpiAwarenessContext = (BOOL (WINAPI *)(DPI_AWARENESS_CONTEXT)) SDL_LoadFunction(data->userDLL, "IsValidDpiAwarenessContext");
     } else {
         SDL_ClearError();
     }

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -249,9 +249,9 @@ WIN_SetAllowHighDPI(_THIS)
     SDL_VideoData *data = SDL_static_cast(SDL_VideoData *, _this->driverdata);
 
     // Declare DPI aware (may have been done in external code or a manifest, as well)
-    if (data->SetProcessDpiAwarenessContext) {
+    if (data->SetThreadDpiAwarenessContext) {
         /* Windows 10 Creators Update+ */
-        data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+        data->SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
     }
 
     // Check for PMv2 context

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -176,6 +176,7 @@ typedef struct SDL_VideoData
     BOOL (WINAPI *AdjustWindowRectExForDpi)( LPRECT, DWORD, BOOL, DWORD, UINT );
     UINT (WINAPI *GetDpiForWindow)( HWND );
     BOOL (WINAPI *AreDpiAwarenessContextsEqual)(DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT);
+    BOOL (WINAPI *IsValidDpiAwarenessContext)(DPI_AWARENESS_CONTEXT);
 
     void* shcoreDLL;
     HRESULT (WINAPI *GetDpiForMonitor)( HMONITOR         hmonitor,

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -186,8 +186,6 @@ typedef struct SDL_VideoData
     HRESULT (WINAPI *SetProcessDpiAwareness)(PROCESS_DPI_AWARENESS dpiAwareness);
 
     SDL_bool highdpi_enabled;
-    int system_xdpi;
-    int system_ydpi;
 
     SDL_bool ime_com_initialized;
     struct ITfThreadMgr *ime_threadmgr;

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -86,9 +86,39 @@ typedef enum MONITOR_DPI_TYPE {
     MDT_DEFAULT = MDT_EFFECTIVE_DPI
 } MONITOR_DPI_TYPE;
 
+typedef enum PROCESS_DPI_AWARENESS {
+    PROCESS_DPI_UNAWARE = 0,
+    PROCESS_SYSTEM_DPI_AWARE = 1,
+    PROCESS_PER_MONITOR_DPI_AWARE = 2
+} PROCESS_DPI_AWARENESS;
+
 #else
 #include <shellscalingapi.h>
 #endif /* WINVER < 0x0603 */
+
+#ifndef _DPI_AWARENESS_CONTEXTS_
+
+typedef enum DPI_AWARENESS {
+    DPI_AWARENESS_INVALID = -1,
+    DPI_AWARENESS_UNAWARE = 0,
+    DPI_AWARENESS_SYSTEM_AWARE = 1,
+    DPI_AWARENESS_PER_MONITOR_AWARE = 2
+} DPI_AWARENESS;
+
+DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
+
+#define DPI_AWARENESS_CONTEXT_UNAWARE           ((DPI_AWARENESS_CONTEXT)-1)
+#define DPI_AWARENESS_CONTEXT_SYSTEM_AWARE      ((DPI_AWARENESS_CONTEXT)-2)
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE ((DPI_AWARENESS_CONTEXT)-3)
+
+#endif /* _DPI_AWARENESS_CONTEXTS_ */
+
+/* Windows 10 Creators Update */
+#if NTDDI_VERSION < 0x0A000003
+
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
+
+#endif /* NTDDI_VERSION < 0x0A000003 */
 
 typedef BOOL  (*PFNSHFullScreen)(HWND, DWORD);
 typedef void  (*PFCoordTransform)(SDL_Window*, POINT*);
@@ -137,13 +167,27 @@ typedef struct SDL_VideoData
     BOOL (WINAPI *CloseTouchInputHandle)( HTOUCHINPUT );
     BOOL (WINAPI *GetTouchInputInfo)( HTOUCHINPUT, UINT, PTOUCHINPUT, int );
     BOOL (WINAPI *RegisterTouchWindow)( HWND, ULONG );
+    BOOL (WINAPI *SetProcessDPIAware)( void );
+    BOOL (WINAPI *SetProcessDpiAwarenessContext)( DPI_AWARENESS_CONTEXT );
+    DPI_AWARENESS_CONTEXT (WINAPI *SetThreadDpiAwarenessContext)( DPI_AWARENESS_CONTEXT );
+    DPI_AWARENESS_CONTEXT (WINAPI *GetThreadDpiAwarenessContext)( void );
+    DPI_AWARENESS (WINAPI *GetAwarenessFromDpiAwarenessContext)( DPI_AWARENESS_CONTEXT );
+    BOOL (WINAPI *EnableNonClientDpiScaling)( HWND );
+    BOOL (WINAPI *AdjustWindowRectExForDpi)( LPRECT, DWORD, BOOL, DWORD, UINT );
+    UINT (WINAPI *GetDpiForWindow)( HWND );
+    BOOL (WINAPI *AreDpiAwarenessContextsEqual)(DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT);
 
     void* shcoreDLL;
     HRESULT (WINAPI *GetDpiForMonitor)( HMONITOR         hmonitor,
                                         MONITOR_DPI_TYPE dpiType,
                                         UINT             *dpiX,
                                         UINT             *dpiY );
-    
+    HRESULT (WINAPI *SetProcessDpiAwareness)(PROCESS_DPI_AWARENESS dpiAwareness);
+
+    SDL_bool highdpi_enabled;
+    int system_xdpi;
+    int system_ydpi;
+
     SDL_bool ime_com_initialized;
     struct ITfThreadMgr *ime_threadmgr;
     SDL_bool ime_initialized;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -762,12 +762,7 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
     int x, y;
     int w, h;
 
-    /* BUG: windows don't receive a WM_DPICHANGED message after a ChangeDisplaySettingsEx,
-       so we must manually update the cached DPI (see WIN_SetDisplayMode). */
-#ifdef HIGHDPI_DEBUG
-    SDL_Log("WIN_SetWindowFullscreen: dpi: %d, stale cached dpi: %d", WIN_GetDPIForHWND(videodata, hwnd), data->scaling_dpi);
-#endif
-    data->scaling_dpi = WIN_GetDPIForHWND(videodata, hwnd);
+    SDL_Log("WIN_SetWindowFullscreen %d", (int)fullscreen);
 
     /* clear the window size, to cause us to send a SDL_WINDOWEVENT_RESIZED event in WM_WINDOWPOSCHANGED */
     data->window->w = 0;
@@ -805,6 +800,8 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
             data->windowed_mode_was_maximized = SDL_TRUE;
             style &= ~WS_MAXIMIZE;
         }
+
+        data->scaling_dpi = 96;
     } else {
         BOOL menu;
 
@@ -819,6 +816,8 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
             data->windowed_mode_was_maximized = SDL_FALSE;
         }
 
+        data->scaling_dpi = WIN_GetDPIForHWND(videodata, data->hwnd);
+
         menu = (style & WS_CHILDWINDOW) ? FALSE : (GetMenu(hwnd) != NULL);
         WIN_AdjustWindowRectWithStyle(window, style, menu, &x, &y, &w, &h, SDL_FALSE);
     }
@@ -826,6 +825,8 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
     data->expected_resize = SDL_TRUE;
     SetWindowPos(hwnd, top, x, y, w, h, SWP_NOCOPYBITS | SWP_NOACTIVATE);
     data->expected_resize = SDL_FALSE;
+
+    SDL_Log("WIN_SetWindowFullscreen %d done. Set window to %d,%d, %dx%d", (int)fullscreen, x, y, w, h);
 }
 
 int

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -296,11 +296,10 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
         }
     }
     {
-        RECT rect;
         POINT point;
         point.x = 0;
         point.y = 0;
-        if (ClientToScreen(hwnd, &point) && GetClientRect(hwnd, &rect)) {
+        if (ClientToScreen(hwnd, &point)) {
             int x = point.x;
             int y = point.y;
             WIN_ScreenPointToSDL(&x, &y);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -278,8 +278,7 @@ WIN_GetDPIForHWND(const SDL_VideoData *videodata, HWND hwnd, int *xdpi, int *ydp
     }
 
     /* Windows Vista-8.0 */
-    *xdpi = videodata->system_xdpi;
-    *ydpi = videodata->system_ydpi;
+    /* no SDL2 highdpi support */
 }
 
 static int

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -345,9 +345,7 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
         if (ClientToScreen(hwnd, &point) && GetClientRect(hwnd, &rect)) {
             int x = point.x;
             int y = point.y;
-            int w = rect.right;
-            int h = rect.bottom;
-            WIN_ScreenRectToSDL(&x, &y, &w, &h);
+            WIN_ScreenPointToSDL(&x, &y);
             window->x = x;
             window->y = y;
         }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -823,11 +823,18 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
         }
         
         int curr_dpi = WIN_GetDPIForHWND(videodata, data->hwnd);
-        SDL_Log("Leaving fullscreen, current window dpi is %d", curr_dpi);
+        
+        UINT dpi_x = 0, dpi_y = 0;
+        videodata->GetDpiForMonitor(displaydata->MonitorHandle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
+        int mon_dpi = dpi_x;
 
         menu = (style & WS_CHILDWINDOW) ? FALSE : (GetMenu(hwnd) != NULL);
 
+        //data->scaling_dpi = mon_dpi;
 
+        SDL_Log("Leaving fullscreen, current window dpi is %d mon dpi %d", curr_dpi, mon_dpi);
+
+        //WIN_AdjustWindowRectWithStyle(window, style, menu, &x, &y, &w, &h, SDL_FALSE, SDL_FALSE);
         WIN_AdjustWindowRectWithStyle(window, style, menu, &x, &y, &w, &h, SDL_FALSE, SDL_TRUE);
     }
     SetWindowLong(hwnd, GWL_STYLE, style);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1163,12 +1163,19 @@ WIN_UpdateClipCursor(SDL_Window *window)
                 ClientToScreen(data->hwnd, (LPPOINT) & rect);
                 ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
                 if (window->mouse_rect.w > 0 && window->mouse_rect.h > 0) {
+                    SDL_Rect mouse_rect_win_client;
                     RECT mouse_rect, intersection;
 
-                    mouse_rect.left = rect.left + window->mouse_rect.x;
-                    mouse_rect.top = rect.top + window->mouse_rect.y;
-                    mouse_rect.right = mouse_rect.left + window->mouse_rect.w - 1;
-                    mouse_rect.bottom = mouse_rect.top + window->mouse_rect.h - 1;
+                    /* mouse_rect_win_client is the mouse rect in Windows client space */
+                    mouse_rect_win_client = window->mouse_rect;
+                    WIN_ClientPointFromSDL(window, &mouse_rect_win_client.x, &mouse_rect_win_client.y);
+                    WIN_ClientPointFromSDL(window, &mouse_rect_win_client.w, &mouse_rect_win_client.h);
+
+                    /* mouse_rect is the rect in Windows screen space */
+                    mouse_rect.left = rect.left + mouse_rect_win_client.x;
+                    mouse_rect.top = rect.top + mouse_rect_win_client.y;
+                    mouse_rect.right = mouse_rect.left + mouse_rect_win_client.w - 1;
+                    mouse_rect.bottom = mouse_rect.top + mouse_rect_win_client.h - 1;
                     if (IntersectRect(&intersection, &rect, &mouse_rect)) {
                         SDL_memcpy(&rect, &intersection, sizeof(rect));
                     } else if ((window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0) {

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -801,7 +801,7 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
             style &= ~WS_MAXIMIZE;
         }
 
-        data->scaling_dpi = 96;
+        //data->scaling_dpi = 96;
     } else {
         BOOL menu;
 
@@ -816,7 +816,7 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
             data->windowed_mode_was_maximized = SDL_FALSE;
         }
 
-        data->scaling_dpi = WIN_GetDPIForHWND(videodata, data->hwnd);
+        //data->scaling_dpi = WIN_GetDPIForHWND(videodata, data->hwnd);
 
         menu = (style & WS_CHILDWINDOW) ? FALSE : (GetMenu(hwnd) != NULL);
         WIN_AdjustWindowRectWithStyle(window, style, menu, &x, &y, &w, &h, SDL_FALSE);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -24,6 +24,7 @@
 
 #include "../../core/windows/SDL_windows.h"
 
+#include "SDL_log.h"
 #include "../SDL_sysvideo.h"
 #include "../SDL_pixels_c.h"
 #include "../../events/SDL_keyboard_c.h"
@@ -44,6 +45,8 @@
 #ifndef SWP_NOCOPYBITS
 #define SWP_NOCOPYBITS 0
 #endif
+
+/* #define HIGHDPI_DEBUG */
 
 /* Fake window to help with DirectInput events. */
 HWND SDL_HelperWindow = NULL;
@@ -112,29 +115,95 @@ GetWindowStyle(SDL_Window * window)
     return style;
 }
 
+/*
+in: client rect (in Windows coordinates)
+out: window rect, including frame (in Windows coordinates)
+*/
 static void
-WIN_AdjustWindowRectWithStyle(SDL_Window *window, DWORD style, BOOL menu, int *x, int *y, int *width, int *height, SDL_bool use_current)
+WIN_AdjustWindowRectWithStyleAndRect(SDL_Window *window, DWORD style, BOOL menu, int *x, int *y, int *width, int *height)
 {
+    const SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
     RECT rect;
 
     rect.left = 0;
     rect.top = 0;
-    rect.right = (use_current ? window->w : window->windowed.w);
-    rect.bottom = (use_current ? window->h : window->windowed.h);
+    rect.right = *width;
+    rect.bottom = *height;
 
     /* borderless windows will have WM_NCCALCSIZE return 0 for the non-client area. When this happens, it looks like windows will send a resize message
        expanding the window client area to the previous window + chrome size, so shouldn't need to adjust the window size for the set styles.
      */
     if (!(window->flags & SDL_WINDOW_BORDERLESS))
-        AdjustWindowRectEx(&rect, style, menu, 0);
+        if (data->videodata->highdpi_enabled && data->videodata->AdjustWindowRectExForDpi) {
+            data->videodata->AdjustWindowRectExForDpi(&rect, style, menu, 0, data->scaling_xdpi);
+        } else {
+            AdjustWindowRectEx(&rect, style, menu, 0);
+        }
 
-    *x = (use_current ? window->x : window->windowed.x) + rect.left;
-    *y = (use_current ? window->y : window->windowed.y) + rect.top;
+    *x += rect.left;
+    *y += rect.top;
     *width = (rect.right - rect.left);
     *height = (rect.bottom - rect.top);
 }
 
+/*
+out: window rect, including frame (in Windows coordinates)
+*/
 static void
+WIN_AdjustWindowRectWithStyle(SDL_Window *window, DWORD style, BOOL menu, int *x, int *y, int *width, int *height, SDL_bool use_current)
+{
+    int x_win, y_win;
+    int w_win, h_win;
+
+    const int x_sdl = (use_current ? window->x : window->windowed.x);
+    const int y_sdl = (use_current ? window->y : window->windowed.y);
+    const int w_sdl = (use_current ? window->w : window->windowed.w);
+    const int h_sdl = (use_current ? window->h : window->windowed.h);
+
+    x_win = x_sdl;
+    y_win = y_sdl;
+    w_win = w_sdl;
+    h_win = h_sdl;
+    WIN_ScreenRectFromSDL(&x_win, &y_win, &w_win, &h_win);
+
+    /* NOTE: we don't use the width/height returned by WIN_ScreenRectFromSDL,
+       (which is making a guess of which monitor the rect is considered to be on)
+       but instead calculate width/height using WIN_ClientPointFromSDL 
+       which is using the DPI values that Windows considers the window to have.
+     */
+    w_win = w_sdl;
+    h_win = h_sdl;
+    WIN_ClientPointFromSDL(window, &w_win, &h_win);
+
+    WIN_AdjustWindowRectWithStyleAndRect(window, style, menu, &x_win, &y_win, &w_win, &h_win);
+
+    *x = x_win;
+    *y = y_win;
+    *width = w_win;
+    *height = h_win;
+}
+
+/*
+in: client rect (in Windows coordinates)
+out: window rect, including frame (in Windows coordinates)
+*/
+void
+WIN_AdjustWindowRectWithRect(SDL_Window *window, int *x, int *y, int *width, int *height)
+{
+    SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
+    HWND hwnd = data->hwnd;
+    DWORD style;
+    BOOL menu;
+
+    style = GetWindowLong(hwnd, GWL_STYLE);
+    menu = (style & WS_CHILDWINDOW) ? FALSE : (GetMenu(hwnd) != NULL);
+    WIN_AdjustWindowRectWithStyleAndRect(window, style, menu, x, y, width, height);
+}
+
+/*
+out: window rect, including frame (in Windows coordinates)
+*/
+void
 WIN_AdjustWindowRect(SDL_Window *window, int *x, int *y, int *width, int *height, SDL_bool use_current)
 {
     SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
@@ -163,11 +232,54 @@ WIN_SetWindowPositionInternal(_THIS, SDL_Window * window, UINT flags)
         top = HWND_NOTOPMOST;
     }
 
-    WIN_AdjustWindowRect(window, &x, &y, &w, &h, SDL_TRUE);
+#ifdef HIGHDPI_DEBUG
+    SDL_Log("WIN_SetWindowPositionInternal: SDL window rect: (%d, %d) (%d x %d)", window->x, window->y, window->w, window->h);
+#endif
+
+    WIN_AdjustWindowRect(window, &x, &y, &w, &h, SDL_TRUE);    
+
+#ifdef HIGHDPI_DEBUG
+    SDL_Log("WIN_SetWindowPositionInternal: calling SetWindowPos (%d, %d) (%d x %d)", x, y, w, h);
+#endif
 
     data->expected_resize = SDL_TRUE;
     SetWindowPos(hwnd, top, x, y, w, h, flags);
     data->expected_resize = SDL_FALSE;
+}
+
+static void
+WIN_GetDPIForHWND(const SDL_VideoData *videodata, HWND hwnd, int *xdpi, int *ydpi)
+{
+    *xdpi = 96;
+    *ydpi = 96;
+
+    /* highdpi not requested? */
+    if (!videodata->highdpi_enabled)
+        return;
+
+    /* Window 10+ */
+    if (videodata->GetDpiForWindow) {
+        *xdpi = videodata->GetDpiForWindow(hwnd);
+        *ydpi = *xdpi;
+        return;
+    }
+
+    /* window 8.1+ */
+    if (videodata->GetDpiForMonitor) {
+        HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        if (monitor) {
+            UINT xdpi_uint, ydpi_uint;
+            if (S_OK == videodata->GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &xdpi_uint, &ydpi_uint)) {
+                *xdpi = xdpi_uint;
+                *ydpi = ydpi_uint;
+            }
+        }
+        return;
+    }
+
+    /* Windows Vista-8.0 */
+    *xdpi = videodata->system_xdpi;
+    *ydpi = videodata->system_ydpi;
 }
 
 static int
@@ -192,6 +304,7 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
     data->last_pointer_update = (LPARAM)-1;
     data->videodata = videodata;
     data->initializing = SDL_TRUE;
+    WIN_GetDPIForHWND(videodata, hwnd, &data->scaling_xdpi, &data->scaling_ydpi);
 
     window->driverdata = data;
 
@@ -219,12 +332,17 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
     }
 #endif
 
+    /* Move window to the correct monitor and size it */
+    WIN_SetWindowPositionInternal(_this, window, SWP_NOCOPYBITS | SWP_NOACTIVATE);
+
     /* Fill in the SDL window with the window data */
     {
         RECT rect;
         if (GetClientRect(hwnd, &rect)) {
             int w = rect.right;
             int h = rect.bottom;
+
+            WIN_ClientPointToSDL(window, &w, &h);
             if ((window->windowed.w && window->windowed.w != w) || (window->windowed.h && window->windowed.h != h)) {
                 /* We tried to create a window larger than the desktop and Windows didn't allow it.  Override! */
                 int x, y;
@@ -238,12 +356,18 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
         }
     }
     {
+        RECT rect;
         POINT point;
         point.x = 0;
         point.y = 0;
-        if (ClientToScreen(hwnd, &point)) {
-            window->x = point.x;
-            window->y = point.y;
+        if (ClientToScreen(hwnd, &point) && GetClientRect(hwnd, &rect)) {
+            int x = point.x;
+            int y = point.y;
+            int w = rect.right;
+            int h = rect.bottom;
+            WIN_ScreenRectToSDL(&x, &y, &w, &h);
+            window->x = x;
+            window->y = y;
         }
     }
     {
@@ -304,8 +428,6 @@ WIN_CreateWindow(_THIS, SDL_Window * window)
 {
     HWND hwnd, parent = NULL;
     DWORD style = STYLE_BASIC;
-    int x, y;
-    int w, h;
 
     if (window->flags & SDL_WINDOW_SKIP_TASKBAR) {
         parent = CreateWindow(SDL_Appname, TEXT(""), STYLE_BASIC, 0, 0, 32, 32, NULL, NULL, SDL_Instance, NULL);
@@ -313,11 +435,15 @@ WIN_CreateWindow(_THIS, SDL_Window * window)
 
     style |= GetWindowStyle(window);
 
-    /* Figure out what the window area will be */
-    WIN_AdjustWindowRectWithStyle(window, style, FALSE, &x, &y, &w, &h, SDL_FALSE);
-
+    /* For high-DPI support, it's easier / more robust** to create the window
+       with a width/height of 0, then in SetupWindowData we will check the
+       DPI and adjust the position and size to match window->x,y,w,h.
+       
+       **The reason is, we can't know window DPI for sure until after the
+       window is created.
+    */
     hwnd =
-        CreateWindow(SDL_Appname, TEXT(""), style, x, y, w, h, parent, NULL,
+        CreateWindow(SDL_Appname, TEXT(""), style, CW_USEDEFAULT, 0, 0, 0, parent, NULL,
                      SDL_Instance, NULL);
     if (!hwnd) {
         return WIN_SetError("Couldn't create window");
@@ -681,13 +807,30 @@ WIN_RestoreWindow(_THIS, SDL_Window * window)
 void
 WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, SDL_bool fullscreen)
 {
+    SDL_DisplayData *displaydata = (SDL_DisplayData *) display->driverdata;
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+    SDL_VideoData *videodata = data->videodata;
     HWND hwnd = data->hwnd;
-    SDL_Rect bounds;
+    MONITORINFO minfo;
     DWORD style;
     HWND top;
     int x, y;
     int w, h;
+
+    /* BUG: windows don't receive a WM_DPICHANGED message after a ChangeDisplaySettingsEx,
+       so we must manually update the cached DPI (see WIN_SetDisplayMode). */
+#ifdef HIGHDPI_DEBUG
+    {
+        int xdpi, ydpi;
+        WIN_GetDPIForHWND(videodata, hwnd, &xdpi, &ydpi);
+        SDL_Log("WIN_SetWindowFullscreen: dpi: %d, stale cached dpi: %d", xdpi, data->scaling_xdpi);
+    }
+#endif
+    WIN_GetDPIForHWND(videodata, hwnd, &data->scaling_xdpi, &data->scaling_ydpi);
+
+    /* clear the window size, to cause us to send a SDL_WINDOWEVENT_RESIZED event in WM_WINDOWPOSCHANGED */
+    data->window->w = 0;
+    data->window->h = 0;
 
     if (SDL_ShouldAllowTopmost() && ((window->flags & (SDL_WINDOW_FULLSCREEN|SDL_WINDOW_INPUT_FOCUS)) == (SDL_WINDOW_FULLSCREEN|SDL_WINDOW_INPUT_FOCUS) || window->flags & SDL_WINDOW_ALWAYS_ON_TOP)) {
         top = HWND_TOPMOST;
@@ -699,13 +842,20 @@ WIN_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * display, 
     style &= ~STYLE_MASK;
     style |= GetWindowStyle(window);
 
-    WIN_GetDisplayBounds(_this, display, &bounds);
+    /* Use GetMonitorInfo instead of WIN_GetDisplayBounds because we want the
+       monitor bounds in Windows coordinates (pixels) rather than SDL coordinates (points). */
+    SDL_zero(minfo);
+    minfo.cbSize = sizeof(MONITORINFO);
+    if (!GetMonitorInfo(displaydata->MonitorHandle, &minfo)) {
+        SDL_SetError("GetMonitorInfo failed");
+        return;
+    }
 
     if (fullscreen) {
-        x = bounds.x;
-        y = bounds.y;
-        w = bounds.w;
-        h = bounds.h;
+        x = minfo.rcMonitor.left;
+        y = minfo.rcMonitor.top;
+        w = minfo.rcMonitor.right - minfo.rcMonitor.left;
+        h = minfo.rcMonitor.bottom - minfo.rcMonitor.top;
 
         /* Unset the maximized flag.  This fixes
            https://bugzilla.libsdl.org/show_bug.cgi?id=3215
@@ -1141,6 +1291,48 @@ WIN_SetWindowOpacity(_THIS, SDL_Window * window, float opacity)
     }
 
     return 0;
+}
+
+void
+WIN_GetDrawableSize(const SDL_Window *window, int *w, int *h)
+{
+    const SDL_WindowData *data = ((SDL_WindowData *)window->driverdata);
+    HWND hwnd = data->hwnd;
+    RECT rect;
+
+    if (GetClientRect(hwnd, &rect)) {
+        *w = rect.right;
+        *h = rect.bottom;
+    } else {
+        *w = 0;
+        *h = 0;
+    }
+}
+
+void
+WIN_ClientPointToSDL(const SDL_Window *window, int *x, int *y)
+{
+    const SDL_WindowData *data = ((SDL_WindowData *)window->driverdata);
+    const SDL_VideoData *videodata = data->videodata;
+
+    if (!videodata->highdpi_enabled)
+        return;
+
+    *x = MulDiv(*x, 96, data->scaling_xdpi);
+    *y = MulDiv(*y, 96, data->scaling_ydpi);
+}
+
+void
+WIN_ClientPointFromSDL(const SDL_Window *window, int *x, int *y)
+{
+    const SDL_WindowData *data = ((SDL_WindowData *)window->driverdata);
+    const SDL_VideoData *videodata = data->videodata;
+
+    if (!videodata->highdpi_enabled)
+        return;
+    
+    *x = MulDiv(*x, data->scaling_xdpi, 96);
+    *y = MulDiv(*y, data->scaling_ydpi, 96);
 }
 
 void

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -138,7 +138,10 @@ WIN_AdjustWindowRectWithStyle(SDL_Window *window, DWORD style, BOOL menu, int *x
     *width = (use_current ? window->w : window->windowed.w);
     *height = (use_current ? window->h : window->windowed.h);
 
-    WIN_ScreenRectFromSDL(x, y, width, height, &dpi);
+    /* Convert from SDL coordinate to pixels */
+    WIN_ScreenPointFromSDL(x, y, &dpi);
+    *width = MulDiv(*width, dpi, 96);
+    *height = MulDiv(*height, dpi, 96);
 
     rect.left = *x;
     rect.top = *y;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -46,7 +46,7 @@
 #define SWP_NOCOPYBITS 0
 #endif
 
-/* #define HIGHDPI_DEBUG */
+#define HIGHDPI_DEBUG
 
 /* Fake window to help with DirectInput events. */
 HWND SDL_HelperWindow = NULL;

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -58,8 +58,15 @@ typedef struct
 #if SDL_VIDEO_OPENGL_EGL  
     EGLSurface egl_surface;
 #endif
+    /* NOTE: differing xdpi and ydpi is legacy-only, but we still support it.
+       On Windows 8.1+ it shouldn't happen (GetDpiForMonitor docs promise xdpi and ydpi are equal)
+       and on Windows 10+ it won't (GetDpiForWindow has a single return value).*/
+    int scaling_xdpi;
+    int scaling_ydpi;
 } SDL_WindowData;
 
+extern void WIN_AdjustWindowRectWithRect(SDL_Window *window, int *x, int *y, int *width, int *height);
+extern void WIN_AdjustWindowRect(SDL_Window *window, int *x, int *y, int *width, int *height, SDL_bool use_current);
 extern int WIN_CreateWindow(_THIS, SDL_Window * window);
 extern int WIN_CreateWindowFrom(_THIS, SDL_Window * window, const void *data);
 extern void WIN_SetWindowTitle(_THIS, SDL_Window * window);
@@ -90,6 +97,9 @@ extern SDL_bool WIN_GetWindowWMInfo(_THIS, SDL_Window * window,
 extern void WIN_OnWindowEnter(_THIS, SDL_Window * window);
 extern void WIN_UpdateClipCursor(SDL_Window *window);
 extern int WIN_SetWindowHitTest(SDL_Window *window, SDL_bool enabled);
+extern void WIN_GetDrawableSize(const SDL_Window *window, int *w, int *h);
+extern void WIN_ClientPointToSDL(const SDL_Window *window, int *w, int *h);
+extern void WIN_ClientPointFromSDL(const SDL_Window *window, int *w, int *h);
 extern void WIN_AcceptDragAndDrop(SDL_Window * window, SDL_bool accept);
 extern int WIN_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
 

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -58,11 +58,7 @@ typedef struct
 #if SDL_VIDEO_OPENGL_EGL  
     EGLSurface egl_surface;
 #endif
-    /* NOTE: differing xdpi and ydpi is legacy-only, but we still support it.
-       On Windows 8.1+ it shouldn't happen (GetDpiForMonitor docs promise xdpi and ydpi are equal)
-       and on Windows 10+ it won't (GetDpiForWindow has a single return value).*/
-    int scaling_xdpi;
-    int scaling_ydpi;
+    int scaling_dpi;
 } SDL_WindowData;
 
 extern void WIN_AdjustWindowRectWithRect(SDL_Window *window, int *x, int *y, int *width, int *height);

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -61,8 +61,6 @@ typedef struct
     int scaling_dpi;
 } SDL_WindowData;
 
-extern void WIN_AdjustWindowRectWithRect(SDL_Window *window, int *x, int *y, int *width, int *height);
-extern void WIN_AdjustWindowRect(SDL_Window *window, int *x, int *y, int *width, int *height, SDL_bool use_current);
 extern int WIN_CreateWindow(_THIS, SDL_Window * window);
 extern int WIN_CreateWindowFrom(_THIS, SDL_Window * window, const void *data);
 extern void WIN_SetWindowTitle(_THIS, SDL_Window * window);


### PR DESCRIPTION
TODO:

- [ ] handle `--allow-highdpi` on an exe that has "Windows Explorer -> Properties -> Compatibility -> High DPI -> Scaled by Application" set.
- [x] touch events probably need DPI scaling applied
- [ ] report/send patch for `D3D_ActivateRenderer(renderer);` after `data->updateSize = SDL_TRUE;` in SDL_render_3d.c issue
- [ ] prototype "always DPI aware" approach (grab code from first squashed commit on the branch)
- [ ] use SDL's logging categories rather than ifdef's?
- [x] (2021-11-22): can't go exclusive fullscreen with testwm2 with `--allow-highdpi --info all --renderer direct3d11`
    - can't repro?
- [x] (2021-11-21): testgl2 with `--allow-highdpi --resizable`, 150% monitor. Ctrl+Enter for fullscreen, then Ctrl+Enter to exit fullscreen. Window is too small
    - fixed by putting a `break;` at the start of the `WM_DPICHANGED` handler
    - edit: this didn't actually fix it
    - `--renderer direct3d11` seems to resolve this though? DX9 only?
    - actual fix: call `D3D_ActivateRenderer(renderer);` after `data->updateSize = SDL_TRUE;` in SDL_render_3d.c
- [x] Fullscreen (Ctrl+Enter in testwm2) on 2 monitor setup, 125% and 100%, goes fullscreen on wrong window. Also happens on `main`
  - also both monitors seem to change modes, when only 1 should
  - 2021-11-06: can't seem to reproduce going fullscreen on the wrong window in this case, but it goes into the wrong fullscreen mode as displayed by the monitor's OSD (1280x740), window before going fullscren is 640x480 points (800x600 pixels) on 3840x2160 px 125% monitor.
- [x] testwm2 with `--allow-highdpi --info all` on 3840x2160 px @ 125% monitor. Alt+Enter gives the following - shouldn't Window size be 3072x1728 points, and the mouse position is also in pixels not points. (global mouse pos is in points  though!)
![image](https://user-images.githubusercontent.com/239161/140621468-5b8bb537-9950-42a6-acc8-caf854b8a94a.png)
- [x] (2021-11-21): testgl2 with `--allow-highdpi`, 150% monitor, renders like: ![image](https://user-images.githubusercontent.com/239161/142780709-971eb916-4f72-45bf-b994-e72aea43e39a.png)
    - calling `data->SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);`
    - `data->AreDpiAwarenessContextsEqual(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, data->GetThreadDpiAwarenessContext())` was returning true
    - fixed by changing `SetThreadDpiAwarenessContext` call to `SetProcessDpiAwarenessContext`. Apparently the OpenGL driver (nvidia) needs the process DPI awareness set?

Notes:

- beware of Windows flagging processes as DPI aware after they change the display mode, see: https://github.com/libsdl-org/SDL/issues/4908#issuecomment-974893441

Testing matrix:

- render / video backends:
  - testwm2 `--renderer direct3d11`
  - testwm2 `--renderer direct3d`
  - testwm2 `--renderer opengl`
  - testgl2
  - testvulkan
  - testgles2
- DPI awareness levels
  - unaware
  - system
  - per-monitor
  - per-monitor V2